### PR TITLE
Declare tighter lower bound on `base`

### DIFF
--- a/text-region.cabal
+++ b/text-region.cabal
@@ -24,7 +24,7 @@ library
     Data.Text.Region
     Data.Text.Region.Types
   build-depends:
-    base >= 4.8 && < 5,
+    base >= 4.9 && < 5,
     base-unicode-symbols >= 0.2,
     aeson >= 0.9,
     bytestring >= 0.10,


### PR DESCRIPTION
`Data.Semigroup` is only available in `base` since base-4.9

```
Configuring library for text-region-0.3.1.0..
Preprocessing library for text-region-0.3.1.0..
Building library for text-region-0.3.1.0..

src/Data/Text/Region/Types.hs:25:8:
    Could not find module ‘Data.Semigroup’
```

moroever, older releases had too optimistic upper bounds on `base`:

```
Configuring library for text-region-0.3.0.0..
Preprocessing library for text-region-0.3.0.0..
Building library for text-region-0.3.0.0..
[1 of 2] Compiling Data.Text.Region.Types ( src/Data/Text/Region/Types.hs, /tmp/matrix-worker/1535015010/dist-newstyle/build/x86_64-linux/ghc-8.4.3/text-region-0.3.0.0/build/Data/Text/Region/Types.o )

src/Data/Text/Region/Types.hs:188:37: error:
    • No instance for (Semigroup (Edit s))
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Monoid (Edit s))
    |
188 |                 deriving (Eq, Show, Monoid)

    |                                     ^^^^^^
<<ghc: 532531912 bytes, 157 GCs, 21040310/74323696 avg/max bytes residency (9 samples), 173M in use, 0.001 INIT (0.001 elapsed), 0.425 MUT (0.435 elapsed), 0.610 GC (0.611 elapsed) :ghc>>


```

I've already revised the affected release at

 - https://hackage.haskell.org/package/text-region-0.1.0.1/revisions/
 - https://hackage.haskell.org/package/text-region-0.2.0.0/revisions/
 - https://hackage.haskell.org/package/text-region-0.3.0.0/revisions/
 - https://hackage.haskell.org/package/text-region-0.3.1.0/revisions/

so there's no need of immediate action from your part.

You can review the current situation at https://matrix.hackage.haskell.org/package/text-region

If you have any questions please let me know!