### PR TITLE
Make `applyMap` more pointful

### DIFF
--- a/src/Data/Text/Region.hs
+++ b/src/Data/Text/Region.hs
@@ -79,7 +79,7 @@ overlaps l r
 	| otherwise = True
 
 applyMap ∷ Map → Region → Region
-applyMap = view ∘ mapIso
+applyMap m = view $ mapIso m
 
 -- | Cut 'Region' mapping
 cutMap ∷ Region → Map


### PR DESCRIPTION
With the changes made in `ghc-9.0.1`, some functions need to be made more "pointful" in order to compile. This patch allows for compiling on `ghc-9.0.2`.

See:
https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst#costs-and-drawbacks